### PR TITLE
Add subtitle tracks loaded event listener

### DIFF
--- a/src/components/AdvancedControls.js
+++ b/src/components/AdvancedControls.js
@@ -165,6 +165,8 @@ class AdvancedControls extends React.Component {
   }
 
   render() {
+    if(!this.props.videoStore.playoutOptions) { return null; }
+
     const toggleButton = (
       <div className="controls-container advanced-controls-toggle">
         <div className="control-row">

--- a/src/components/PlayoutControls.js
+++ b/src/components/PlayoutControls.js
@@ -70,6 +70,8 @@ class PlayoutControls extends React.Component {
   }
 
   render() {
+    if(!this.props.videoStore.playoutOptions) { return null; }
+
     return (
       <div className="controls-container playout-controls">
         <h3 className="controls-header">Playout Options</h3>

--- a/src/components/Video.js
+++ b/src/components/Video.js
@@ -131,6 +131,13 @@ class Video extends React.Component {
       });
     });
 
+    this.player.on(HLSPlayer.Events.SUBTITLE_TRACKS_UPDATED, () => {
+      this.props.videoStore.SetTextTracks({
+        tracks: Array.from(this.video.textTracks),
+        currentTrack: this.player.subtitleTrack
+      });
+    });
+
     this.player.on(HLSPlayer.Events.SUBTITLE_TRACK_LOADED, () => {
       this.props.videoStore.SetTextTracks({
         tracks: Array.from(this.video.textTracks),
@@ -388,6 +395,7 @@ class Video extends React.Component {
           {
             this.props.videoStore.playerTextTracks.map((track, index) => {
               let label;
+
               try {
                 label = this.props.videoStore.protocol === "dash" ?
                   this.player.getTracksFor("text")[index].labels[0].text :


### PR DESCRIPTION
Add event for SUBTITLE_TRACKS_UPDATED to set text tracks.
Additionally, wait to show right panel actions until playout options have been determined. This removes race conditions when the user clicks on a playout option before the player has been fully initialized.