### PR TITLE
Add playout method drm check when switching with error handling

### DIFF
--- a/src/stores/VideoStore.js
+++ b/src/stores/VideoStore.js
@@ -143,7 +143,7 @@ class VideoStore {
     if(this.playoutOptions) {
       // Prefer clear
       const playoutMethods = this.playoutOptions[this.protocol].playoutMethods;
-      this.drm = playoutMethods.clear ? "clear" : (playoutMethods[this.aesOption] ? this.aesOption : "widevine");
+      this.drm = playoutMethods.clear ? "clear" : (playoutMethods[this.aesOption] ? this.aesOption : playoutMethods.widevine ? "widevine" : "fairplay");
     } else if(this.drm !== "clear") {
       this.drm = this.protocol === "hls" ? this.aesOption : "widevine";
     }
@@ -293,7 +293,18 @@ class VideoStore {
     if(!playoutOptions[this.protocol].playoutMethods[this.drm]) {
       // Prefer DRM
       const playoutMethods = playoutOptions[this.protocol].playoutMethods;
-      this.drm = playoutMethods.clear ? "clear" : (playoutMethods[this.aesOption] ? this.aesOption : "widevine");
+      if(playoutMethods.clear) {
+        this.drm = "clear";
+      } else if(playoutMethods[this.aesOption]) {
+        this.drm = this.aesOption;
+      } else if(playoutMethods.widevine) {
+        this.drm = "widevine";
+      } else if(playoutMethods.fairplay) {
+        this.drm = "fairplay";
+      } else {
+        this.SetError("No playout formats compatible with this browser are available.");
+        return;
+      }
     }
 
     this.playoutOptions = playoutOptions;


### PR DESCRIPTION
Add additional check to switch to a browser-supported DRM. Throw an error when no supported DRMs are listed in playout methods for a given protocol.

For further improvement, it might be good to have a list of DRMs in order of priority to switch to instead of doing a manual ternary switch.